### PR TITLE
feat: add chisel-wrapper script

### DIFF
--- a/chisel-wrapper
+++ b/chisel-wrapper
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# USAGE:
+#   ./<script-name> [ chisel-cut-OPTIONS ] <slices..>
+# Installs the slices, using
+#   chisel cut "$@"
+# Generates a status file similar to /var/lib/dpkg/status at the CHISEL_DPKG_STATUS_FILE path
+# env vars:
+#   CHISEL_BIN                (optional) the path of chisel binary
+#   CHISEL_CACHE_DIR          (optional) the path which chisel will use to store it's cache
+#   CHISEL_DPKG_STATUS_FILE   (required) the path where the dpkg status file should be generated
+
+set -eu
+
+CHISEL_BIN="${CHISEL_BIN:-"chisel"}"
+CHISEL_CACHE_DIR="${CHISEL_CACHE_DIR:-"$(mktemp -d)"}"
+
+_print_error() {
+	echo "Error:" "$@" >> /dev/stderr
+}
+
+_install_slices() {
+	XDG_CACHE_HOME="$CHISEL_CACHE_DIR" $CHISEL_BIN cut "$@"
+}
+
+_prepare_dpkg_status() {
+	dir="$CHISEL_CACHE_DIR/chisel/sha256"
+	if [ ! -d "$dir" ]; then
+		_print_error "could not find the chisel cache at ${dir}"
+		exit 1
+	fi
+
+	if [ -f "$CHISEL_DPKG_STATUS_FILE" ]; then
+		rm -f "$CHISEL_DPKG_STATUS_FILE"
+	fi
+
+	for f in "$dir"/*; do
+		is_deb="$(file "$f" | grep "Debian binary package" | cat)"
+		if [ -z "$is_deb" ]; then
+			continue
+		fi
+		dpkg-deb -f "$f" >> "$CHISEL_DPKG_STATUS_FILE"
+		echo "" >> "$CHISEL_DPKG_STATUS_FILE"
+	done
+}
+
+if [ -z "$CHISEL_DPKG_STATUS_FILE" ] ; then
+	_print_error "please specify the desired path of dpkg status in CHISEL_DPKG_STATUS_FILE"
+	exit 1
+fi
+
+_install_slices "$@"
+_prepare_dpkg_status

--- a/chisel-wrapper
+++ b/chisel-wrapper
@@ -19,7 +19,7 @@ print_usage() {
 
 	[OPTIONS]
 
-	  -g, --generate-dpkg-status <path>
+	  --generate-dpkg-status <path>
 	      Generate a dpkg status file at the specified <path>.
 
 	  -h, --help
@@ -71,7 +71,7 @@ prepare_dpkg_status() {
 
 while (( "$#" )); do
 	case "$1" in
-		-g|--generate-dpkg-status)
+		--generate-dpkg-status)
 			if (( "$#" < 2 )); then
 				print_error "Please specify the desired path of the dpkg status file."
 				exit 1

--- a/chisel-wrapper
+++ b/chisel-wrapper
@@ -1,27 +1,42 @@
 #!/bin/bash
 
-# USAGE:
-#
-#   ./<script> [ chisel-cut-OPTIONS ] <slices..>
-#
-# Installs the slices, using
-#
-#   chisel cut "$@"
-#
-# Generates a status file similar to /var/lib/dpkg/status
-# at the CHISEL_DPKG_STATUS_FILE path.
-#
-# env vars:
-#   CHISEL_BIN                (optional) the path of chisel binary
-#   CHISEL_DPKG_STATUS_FILE   (required) the path where the dpkg status file should be generated
-
 set -eu
 
 CHISEL_BIN="${CHISEL_BIN:-"chisel"}"
+
 CHISEL_CACHE_DIR="$(mktemp -d)"
+CHISEL_DPKG_STATUS_FILE=""
+
+print_usage() {
+	cat <<- EOF
+	Usage: $(basename "$0") [OPTIONS] -- [chisel-cut-OPTIONS] <slice names..>
+
+	This wrapper script performs "chisel cut" operation on specified slices.
+	And if specified in OPTIONS, it performs various tasks such as generating
+	a dpkg status file for the installed file system.
+
+	Every argument after -- will be passed to "chisel cut".
+
+	[OPTIONS]
+
+	  -g, --generate-dpkg-status <path>
+	      Generate a dpkg status file at the specified <path>.
+
+	  -h, --help
+	      Print this help information and quit.
+
+	ENVIRONMENT VARIABLES
+
+	  CHISEL_BIN
+	      Set CHISEL_BIN to the location of the chisel binary.
+	      By default, it will look for "chisel" in PATH.
+	EOF
+}
 
 cleanup() {
-	rm -rf "$CHISEL_CACHE_DIR"
+	if [ -d "$CHISEL_CACHE_DIR" ]; then
+		rm -rf "$CHISEL_CACHE_DIR"
+	fi
 }
 trap cleanup EXIT
 
@@ -54,10 +69,37 @@ prepare_dpkg_status() {
 	done
 }
 
-if [ -z "${CHISEL_DPKG_STATUS_FILE:-}" ] ; then
-	print_error "please specify the desired path of dpkg status in CHISEL_DPKG_STATUS_FILE"
-	exit 1
-fi
+while (( "$#" )); do
+	case "$1" in
+		-g|--generate-dpkg-status)
+			if (( "$#" < 2 )); then
+				print_error "Please specify the desired path of the dpkg status file."
+				exit 1
+			fi
+			CHISEL_DPKG_STATUS_FILE="$2"
+			shift 2
+			;;
+		-h|--help)
+			print_usage
+			exit 0
+			;;
+		--)
+			shift
+			break
+			;;
+		-*)
+			echo "Unknown option: $1"
+			exit 1
+			;;
+		*)
+			echo "Unexpected argument: $1"
+			exit 1
+			;;
+	esac
+done
 
 install_slices "$@"
-prepare_dpkg_status
+
+if [ -n "$CHISEL_DPKG_STATUS_FILE" ]; then
+	prepare_dpkg_status
+fi

--- a/chisel-wrapper
+++ b/chisel-wrapper
@@ -1,32 +1,42 @@
 #!/bin/bash
 
 # USAGE:
-#   ./<script-name> [ chisel-cut-OPTIONS ] <slices..>
+#
+#   ./<script> [ chisel-cut-OPTIONS ] <slices..>
+#
 # Installs the slices, using
+#
 #   chisel cut "$@"
-# Generates a status file similar to /var/lib/dpkg/status at the CHISEL_DPKG_STATUS_FILE path
+#
+# Generates a status file similar to /var/lib/dpkg/status
+# at the CHISEL_DPKG_STATUS_FILE path.
+#
 # env vars:
 #   CHISEL_BIN                (optional) the path of chisel binary
-#   CHISEL_CACHE_DIR          (optional) the path which chisel will use to store it's cache
 #   CHISEL_DPKG_STATUS_FILE   (required) the path where the dpkg status file should be generated
 
 set -eu
 
 CHISEL_BIN="${CHISEL_BIN:-"chisel"}"
-CHISEL_CACHE_DIR="${CHISEL_CACHE_DIR:-"$(mktemp -d)"}"
+CHISEL_CACHE_DIR="$(mktemp -d)"
 
-_print_error() {
+cleanup() {
+	rm -rf "$CHISEL_CACHE_DIR"
+}
+trap cleanup EXIT
+
+print_error() {
 	echo "Error:" "$@" >> /dev/stderr
 }
 
-_install_slices() {
+install_slices() {
 	XDG_CACHE_HOME="$CHISEL_CACHE_DIR" $CHISEL_BIN cut "$@"
 }
 
-_prepare_dpkg_status() {
+prepare_dpkg_status() {
 	dir="$CHISEL_CACHE_DIR/chisel/sha256"
 	if [ ! -d "$dir" ]; then
-		_print_error "could not find the chisel cache at ${dir}"
+		print_error "could not find the chisel cache at ${dir}"
 		exit 1
 	fi
 
@@ -45,9 +55,9 @@ _prepare_dpkg_status() {
 }
 
 if [ -z "$CHISEL_DPKG_STATUS_FILE" ] ; then
-	_print_error "please specify the desired path of dpkg status in CHISEL_DPKG_STATUS_FILE"
+	print_error "please specify the desired path of dpkg status in CHISEL_DPKG_STATUS_FILE"
 	exit 1
 fi
 
-_install_slices "$@"
-_prepare_dpkg_status
+install_slices "$@"
+prepare_dpkg_status

--- a/chisel-wrapper
+++ b/chisel-wrapper
@@ -26,7 +26,7 @@ cleanup() {
 trap cleanup EXIT
 
 print_error() {
-	echo "Error:" "$@" >> /dev/stderr
+	echo "Error:" "$@" >&2
 }
 
 install_slices() {
@@ -54,7 +54,7 @@ prepare_dpkg_status() {
 	done
 }
 
-if [ -z "$CHISEL_DPKG_STATUS_FILE" ] ; then
+if [ -z "${CHISEL_DPKG_STATUS_FILE:-}" ] ; then
 	print_error "please specify the desired path of dpkg status in CHISEL_DPKG_STATUS_FILE"
 	exit 1
 fi


### PR DESCRIPTION
This wrapper script installs the slices and can generate an artificial status file similar to `/var/lib/dpkg/status`.

Basic usage:

	export CHISEL_DPKG_STATUS_FILE=/path/to/file
	chisel-wrapper [chisel-cut-OPTIONS] <slices..>

Please read through the script for detailed usage info.