### PR TITLE
fix: renovate regex for rockcraft tag

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,10 +14,10 @@
         "^rockcraft_rock/rockcraft.yaml$"
       ],
       "matchStrings": [
-        "source-tag: (?<currentValue>.*?)\\s"
+        "rockcraft$\s+source-tag:\s+(?<currentValue>.*?)"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "canonical/chisel"
+      "depNameTemplate": "canonical/rockcraft"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
         "^rockcraft_rock/rockcraft.yaml$"
       ],
       "matchStrings": [
-        "rockcraft$\s+source-tag:\s+(?<currentValue>.*?)"
+        "rockcraft\\.git[\\s]*?$[\\s]*?source-tag:\\s+(?<currentValue>.*?)\\s"
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "canonical/rockcraft"


### PR DESCRIPTION
Match only the `source-tag` after the `rockcraft.git` keyword