### PR TITLE
feat: rockcraft snap patcher

### DIFF
--- a/rockcraft_snap_patcher/README.md
+++ b/rockcraft_snap_patcher/README.md
@@ -1,7 +1,7 @@
 # Rockcraft Patcher
 
 `patcher.sh` enables quick rockcraft "builds" for development by patching 
-an existing snap package with changes made to dependancies on the local
+an existing snap package with changes made to dependencies on the local
 system.  
 
 ## How to use

--- a/rockcraft_snap_patcher/README.md
+++ b/rockcraft_snap_patcher/README.md
@@ -1,0 +1,21 @@
+# Rockcraft Patcher
+
+`patcher.sh` enables quick rockcraft "builds" for development by patching 
+an existing snap package with changes made to dependancies on the local
+system.  
+
+## How to use
+
+0. Clone rockcraft, craft-application, craft-providers and craft-parts.
+1. Build a Rockcraft snap package to use as a donor for the patched package.
+2. Place the the `patcher.sh` sciprt in the rockcraft source directory.
+3. Edit the paths in the script to point to the other craft repositories on 
+your system as well as the donor package.
+4. Run `patcher.sh` to create the patched package and install it to the system.
+The installation can be verified by checking `snap list`. Rockcraft should show
+a version number similar to `local-patch-<timestamp>`.
+
+`patcher.sh` can be run as needed for testing changes made to the local repos. 
+
+## TODO: 
+- Support debugging Python in rockcraft. Include VSCodes launch.json

--- a/rockcraft_snap_patcher/patcher.sh
+++ b/rockcraft_snap_patcher/patcher.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+
+# Rockcraft snap package patcher
+# Version 4
+
+set -xe
+
+# configurable vars
+src_snap="rockcraft_1.5.3.post51+gc99aa44.d20241011_amd64.snap" # snap package to modify
+rockcraft="." # Path to rockcraft repo
+craft_application="../craft-application/" # Path to craft_application repo
+craft_providers="../craft-providers/"  # Path to craft_providers repo
+craft_parts="../craft-parts/"  # Path to craft_providers repo
+
+
+# setup
+snap_rootfs="./.patcher/$(uuid)/"
+sudo mkdir -p "$snap_rootfs"
+
+# unpack rootfs
+unsquashfs -f -d "$snap_rootfs" "$src_snap"
+snap_name=$(yq '.name' "$snap_rootfs/meta/snap.yaml")
+# snap_src_version=$(yq '.version' "$snap_rootfs/meta/snap.yaml")
+snap_arch=$(yq '.architectures[0]' "$snap_rootfs/meta/snap.yaml") #TODO: support multi arch?
+
+
+# modify snap rootfs
+rm -rf "$snap_rootfs/lib/python3.10/site-packages/rockcraft"
+rsync -r --chown=root:root "$rockcraft/rockcraft" "$snap_rootfs/lib/python3.10/site-packages/"
+
+rm -rf "$snap_rootfs/lib/python3.10/site-packages/craft_application"
+rsync -r --chown=root:root "$craft_application/craft_application" "$snap_rootfs/lib/python3.10/site-packages/"
+
+rm -rf "$snap_rootfs/lib/python3.10/site-packages/craft_parts"
+rsync -r --chown=root:root "$craft_parts/craft_parts" "$snap_rootfs/lib/python3.10/site-packages/"
+
+rm -rf "$snap_rootfs/lib/python3.10/site-packages/craft_providers"
+rsync -r --chown=root:root "$craft_providers/craft_providers" "$snap_rootfs/lib/python3.10/site-packages/"
+
+# repack and install snap rootfs
+export snap_dst_version="local-patch-$(date +%s)"
+yq e -i ".version= env(snap_dst_version)" "$snap_rootfs/meta/snap.yaml"
+dst_snap="${snap_name}_${snap_dst_version}_${snap_arch}.snap"
+
+rm -f "$dst_snap"
+mksquashfs "$snap_rootfs" "$dst_snap" -noappend -comp lzo -no-fragments
+sudo snap install "$dst_snap" --dangerous --classic
+
+# cleanup
+rm -rf "$snap_rootfs"


### PR DESCRIPTION
`patcher.sh` enables quick rockcraft "builds" for development by patching 
an existing snap package with changes made to dependencies on the local
system.  

