### PR TITLE
feat(chisel-wrapper): update dpkg status file if exists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,41 @@ jobs:
       - uses: actions/setup-python@v5
       - run: pip install -r rockcraft_lpci_build/requirements.test.txt
       - run: pytest rockcraft_lpci_build/tests/ -vvv -s -rP --log-cli-level=INFO
+
+  chisel-wrapper:
+    name: Chisel wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Chisel
+        env:
+          version: v1.1.0
+        run: |
+          wget "https://github.com/canonical/chisel/releases/download/${{ env.version }}/chisel_${{ env.version }}_linux_amd64.tar.gz"
+          tar zxvf "chisel_${{ env.version }}_linux_amd64.tar.gz"
+          sudo mv chisel /usr/local/bin/
+      - name: Test chisel-wrapper
+        run: |
+          install() {
+            ./chisel-wrapper --generate-dpkg-status status -- \
+              --release ubuntu-20.04 --root "$(mktemp -d)" \
+              "$@"
+          }
+
+          cleanup() {
+            rm -f status
+          }
+          trap cleanup EXIT
+
+          test ! -f status
+
+          install openssl_bins
+          grep "^Package:.*$" status | wc -l | grep -q "3"            # must be 3 packages
+
+          install base-files_base
+          grep "^Package:.*$" status | wc -l | grep -q "4"            # must be 4 packages
+          grep "^Package:.*$" status | tail -1 | grep -q "base-files" # must be last entry
+
+          install libc6_libs
+          grep "^Package:.*$" status | wc -l | grep -q "4"            # must be 4 packages
+          grep "^Package:.*$" status | tail -1 | grep -q "libc6"      # must be last entry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,42 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Chisel
-        env:
-          version: v1.1.0
+      - uses: actions/setup-go@v5
+      - name: Install chisel
+        run: go install github.com/canonical/chisel/cmd/chisel@latest
+      - name: Install syft
         run: |
-          wget "https://github.com/canonical/chisel/releases/download/${{ env.version }}/chisel_${{ env.version }}_linux_amd64.tar.gz"
-          tar zxvf "chisel_${{ env.version }}_linux_amd64.tar.gz"
-          sudo mv chisel /usr/local/bin/
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
+          sudo sh -s -- -b /usr/local/bin
       - name: Test chisel-wrapper
-        run: |
-          set -ex
-
-          install() {
-            ./chisel-wrapper --generate-dpkg-status status -- \
-              --release ubuntu-20.04 --root "$(mktemp -d)" \
-              "$@"
-          }
-
-          cleanup() {
-            rm -f status
-          }
-          trap cleanup EXIT
-
-          test ! -f status
-
-          install openssl_bins    # 3 new packages
-          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
-            sort | grep -Pz "libc6\nlibssl1.1\nopenssl"
-
-          install base-files_base # 1 more package
-          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
-            sort | grep -Pz "base-files\nlibc6\nlibssl1.1\nopenssl"
-          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
-            tail -1 | grep -q "base-files" # must be last entry
-
-          install libc6_libs      # no new package
-          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
-            sort | grep -Pz "base-files\nlibc6\nlibssl1.1\nopenssl"
-          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
-            tail -1 | grep -q "libc6"      # must be last entry
+        run: ./tests/chisel-wrapper/runtest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       - run: pytest rockcraft_lpci_build/tests/ -vvv -s -rP --log-cli-level=INFO
 
   chisel-wrapper:
-    name: Chisel wrapper
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,13 +44,18 @@ jobs:
 
           test ! -f status
 
-          install openssl_bins
-          grep "^Package:.*$" status | wc -l | grep -q "3"            # must be 3 packages
+          install openssl_bins    # 3 new packages
+          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
+            sort | grep -Pz "libc6\nlibssl1.1\nopenssl"
 
-          install base-files_base
-          grep "^Package:.*$" status | wc -l | grep -q "4"            # must be 4 packages
-          grep "^Package:.*$" status | tail -1 | grep -q "base-files" # must be last entry
+          install base-files_base # 1 more package
+          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
+            sort | grep -Pz "base-files\nlibc6\nlibssl1.1\nopenssl"
+          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
+            tail -1 | grep -q "base-files" # must be last entry
 
-          install libc6_libs
-          grep "^Package:.*$" status | wc -l | grep -q "4"            # must be 4 packages
-          grep "^Package:.*$" status | tail -1 | grep -q "libc6"      # must be last entry
+          install libc6_libs      # no new package
+          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
+            sort | grep -Pz "base-files\nlibc6\nlibssl1.1\nopenssl"
+          sed -n "s/^Package:\s*\(.*\)$/\1/p" status | \
+            tail -1 | grep -q "libc6"      # must be last entry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
           sudo mv chisel /usr/local/bin/
       - name: Test chisel-wrapper
         run: |
+          set -ex
+
           install() {
             ./chisel-wrapper --generate-dpkg-status status -- \
               --release ubuntu-20.04 --root "$(mktemp -d)" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on:
   push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test-rockcraft-lpci-build:

--- a/chisel-wrapper
+++ b/chisel-wrapper
@@ -55,18 +55,27 @@ prepare_dpkg_status() {
 		exit 1
 	fi
 
-	if [ -f "$CHISEL_DPKG_STATUS_FILE" ]; then
-		rm -f "$CHISEL_DPKG_STATUS_FILE"
-	fi
-
 	for f in "$dir"/*; do
 		is_deb="$(file "$f" | grep "Debian binary package" | cat)"
 		if [ -z "$is_deb" ]; then
 			continue
 		fi
-		dpkg-deb -f "$f" >> "$CHISEL_DPKG_STATUS_FILE"
-		echo "" >> "$CHISEL_DPKG_STATUS_FILE"
+		write_control_file "$f"
 	done
+}
+
+write_control_file() {
+	local f="$1"
+	local pkg
+
+	if [ -f "$CHISEL_DPKG_STATUS_FILE" ]; then
+		# Remove previous entry if it exists.
+		pkg="$(dpkg-deb -f "$f" Package)"
+		sed "/Package:\s*$pkg/,/^\s*$/d" -i "$CHISEL_DPKG_STATUS_FILE"
+	fi
+
+	dpkg-deb -f "$f" >> "$CHISEL_DPKG_STATUS_FILE"
+	echo "" >> "$CHISEL_DPKG_STATUS_FILE"
 }
 
 while (( "$#" )); do

--- a/tests/chisel-wrapper/runtest
+++ b/tests/chisel-wrapper/runtest
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Needs chisel and syft.
+
+set -eux
+
+STATUS_FILE="$(mktemp)"
+ROOTFS="$(mktemp -d)"
+
+install() {
+    ./chisel-wrapper --generate-dpkg-status "$STATUS_FILE" -- \
+        --release ubuntu-20.04 --root "$ROOTFS" \
+        "$@"
+}
+
+place_status() {
+    mkdir -p "$ROOTFS/var/lib/dpkg"
+    cp "$STATUS_FILE" "$ROOTFS/var/lib/dpkg/status"
+}
+
+check_syft() {
+    local match="$1"
+    syft "$ROOTFS" -o syft-table -q | grep deb | cut -d' ' -f1  | \
+        grep -Pz "$match"
+}
+
+cleanup() {
+    rm -f "$STATUS_FILE"
+}
+trap cleanup EXIT
+
+install openssl_bins    # 3 new packages
+place_status
+check_syft "libc6\nlibssl1.1\nopenssl"
+
+install base-files_base # 1 more package
+place_status
+check_syft "base-files\nlibc6\nlibssl1.1\nopenssl"
+
+install libc6_libs      # no new package
+place_status
+check_syft "base-files\nlibc6\nlibssl1.1\nopenssl"


### PR DESCRIPTION
If the ``CHISEL_DPKG_STATUS_FILE`` exists, update the file with the new entries instead of overwriting the file.

If the status file already contains an entry for a new package, remove the previous entry and append the new entry at the bottom of the status file.

Resolves #25.

---

### Testing the new behaviour

To test the new behaviour, I first installed the `openssl_bins` slice from Focal (20.04) release and generated the dpkg status file at `./status`.

```
./chisel-wrapper --generate-dpkg-status status -- --release ubuntu-20.04 --root out/ openssl_bins
```

<details>
<summary>Logs</summary>

```
2025/02/12 15:38:54 Consulting release repository...
2025/02/12 15:38:56 Fetching current ubuntu-20.04 release...
2025/02/12 15:38:57 Processing /tmp/tmp.BiJG8BcetG/chisel/releases/ubuntu-20.04 release...
2025/02/12 15:38:57 Selecting slices...
2025/02/12 15:38:57 Fetching ubuntu-fips-updates fips-updates (pro) 20.04 focal-updates suite details...
2025/02/12 15:38:59 Release date: Mon, 10 Feb 2025 15:20:29 UTC
2025/02/12 15:38:59 Fetching index for ubuntu-fips-updates fips-updates (pro) 20.04 focal-updates main component...
2025/02/12 15:39:03 Fetching ubuntu-esm-apps esm-apps (pro) 20.04 focal-apps-security suite details...
2025/02/12 15:39:03 Release date: Thu, 06 Feb 2025 01:13:05 UTC
2025/02/12 15:39:03 Fetching index for ubuntu-esm-apps esm-apps (pro) 20.04 focal-apps-security main component...
2025/02/12 15:39:05 Fetching ubuntu-esm-apps esm-apps (pro) 20.04 focal-apps-updates suite details...
2025/02/12 15:39:06 Release date: Wed, 10 Aug 2022 20:35:13 UTC
2025/02/12 15:39:06 Fetching index for ubuntu-esm-apps esm-apps (pro) 20.04 focal-apps-updates main component...
2025/02/12 15:39:06 Fetching ubuntu-esm-infra esm-infra (pro) 20.04 focal-infra-security suite details...
2025/02/12 15:39:07 Release date: Tue, 16 Aug 2022 12:06:54 UTC
2025/02/12 15:39:07 Fetching index for ubuntu-esm-infra esm-infra (pro) 20.04 focal-infra-security main component...
2025/02/12 15:39:07 Fetching ubuntu-esm-infra esm-infra (pro) 20.04 focal-infra-updates suite details...
2025/02/12 15:39:07 Release date: Tue, 16 Aug 2022 12:05:13 UTC
2025/02/12 15:39:07 Fetching index for ubuntu-esm-infra esm-infra (pro) 20.04 focal-infra-updates main component...
2025/02/12 15:39:07 Fetching ubuntu-fips fips (pro) 20.04 focal suite details...
2025/02/12 15:39:08 Release date: Wed, 06 Mar 2024 16:15:23 UTC
2025/02/12 15:39:08 Fetching index for ubuntu-fips fips (pro) 20.04 focal main component...
2025/02/12 15:39:08 Fetching ubuntu 20.04 focal suite details...
2025/02/12 15:39:11 Release date: Thu, 23 Apr 2020 17:33:17 UTC
2025/02/12 15:39:11 Fetching index for ubuntu 20.04 focal main component...
2025/02/12 15:39:14 Fetching index for ubuntu 20.04 focal universe component...
2025/02/12 15:39:20 Fetching ubuntu 20.04 focal-security suite details...
2025/02/12 15:39:21 Release date: Wed, 12 Feb 2025  4:56:25 UTC
2025/02/12 15:39:21 Fetching index for ubuntu 20.04 focal-security main component...
2025/02/12 15:39:22 Fetching index for ubuntu 20.04 focal-security universe component...
2025/02/12 15:39:23 Fetching ubuntu 20.04 focal-updates suite details...
2025/02/12 15:39:24 Release date: Wed, 12 Feb 2025  8:24:16 UTC
2025/02/12 15:39:24 Fetching index for ubuntu 20.04 focal-updates main component...
2025/02/12 15:39:25 Fetching index for ubuntu 20.04 focal-updates universe component...
2025/02/12 15:39:35 Fetching pool/main/g/glibc/libc6_2.31-0ubuntu9.17_amd64.deb...
2025/02/12 15:39:39 Fetching pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.fips.23_amd64.deb...
2025/02/12 15:39:40 Fetching pool/main/o/openssl/openssl_1.1.1f-1ubuntu2.fips.23_amd64.deb...
2025/02/12 15:39:41 Extracting files from package "libc6"...
2025/02/12 15:39:49 Extracting files from package "libssl1.1"...
2025/02/12 15:39:53 Extracting files from package "openssl"...
```

</details>

<details>
<summary>Contents of `./status`</summary>

```
Package: libssl1.1
Source: openssl
Version: 1.1.1f-1ubuntu2.fips.23
Architecture: amd64
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Installed-Size: 4097
Depends: libc6 (>= 2.17), debconf (>= 0.5) | debconf-2.0
Recommends: libssl1.1-hmac (= 1.1.1f-1ubuntu2.fips.23)
Breaks: isync (<< 1.3.0-2), lighttpd (<< 1.4.49-2), python-boto (<< 2.44.0-1.1), python-httplib2 (<< 0.11.3-1), python-imaplib2 (<< 2.57-5), python3-boto (<< 2.44.0-1.1), python3-imaplib2 (<< 2.57-5)
Section: libs
Priority: optional
Multi-Arch: same
Homepage: https://www.openssl.org/
Description: Secure Sockets Layer toolkit - shared libraries
 This package is part of the OpenSSL project's implementation of the SSL
 and TLS cryptographic protocols for secure communication over the
 Internet.
 .
 It provides the libssl and libcrypto shared libraries.
Original-Maintainer: Debian OpenSSL Team <pkg-openssl-devel@lists.alioth.debian.org>

Package: libc6
Source: glibc
Version: 2.31-0ubuntu9.17
Architecture: amd64
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Installed-Size: 13239
Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)
Recommends: libidn2-0 (>= 2.0.5~)
Suggests: glibc-doc, debconf | debconf-2.0, locales
Conflicts: openrc (<< 0.27-2~)
Breaks: hurd (<< 1:0.9.git20170910-1), iraf-fitsutil (<< 2018.07.06-4), libtirpc1 (<< 0.2.3), locales (<< 2.31), locales-all (<< 2.31), nocache (<< 1.1-1~), nscd (<< 2.31), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)
Replaces: libc6-amd64
Section: libs
Priority: optional
Multi-Arch: same
Homepage: https://www.gnu.org/software/libc/libc.html
Description: GNU C Library: Shared libraries
 Contains the standard libraries that are used by nearly all programs on
 the system. This package includes shared versions of the standard C library
 and the standard math library, as well as many others.
Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>
Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc
Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git

Package: openssl
Version: 1.1.1f-1ubuntu2.fips.23
Architecture: amd64
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Installed-Size: 1257
Depends: libc6 (>= 2.15), libssl1.1 (>= 1.1.1)
Suggests: ca-certificates
Section: utils
Priority: optional
Multi-Arch: foreign
Homepage: https://www.openssl.org/
Description: Secure Sockets Layer toolkit - cryptographic utility
 This package is part of the OpenSSL project's implementation of the SSL
 and TLS cryptographic protocols for secure communication over the
 Internet.
 .
 It contains the general-purpose command line binary /usr/bin/openssl,
 useful for cryptographic operations such as:
  * creating RSA, DH, and DSA key parameters;
  * creating X.509 certificates, CSRs, and CRLs;
  * calculating message digests;
  * encrypting and decrypting with ciphers;
  * testing SSL/TLS clients and servers;
  * handling S/MIME signed or encrypted mail.
Original-Maintainer: Debian OpenSSL Team <pkg-openssl-devel@lists.alioth.debian.org>

```

</details>

`openssl_bins` installed 3 packages in total:
- libssl1.1 (1.1.1f-1ubuntu2.fips.23)
- libc6 (2.31-0ubuntu9.17)
- openssl (1.1.1f-1ubuntu2.fips.23)

--

To check if the entries truly get updated with the latest run, I installed `libc6_libs` from the Jammy (22.04) release. Jammy has a newer version of `libc6` in the archives, which should help distinguish the difference if there is any.

```
./chisel-wrapper --generate-dpkg-status status -- --release ubuntu-22.04 --root out/ libc6_libs
```

<details>
<summary>Logs</summary>

```
2025/02/12 15:45:26 Consulting release repository...
2025/02/12 15:45:27 Fetching current ubuntu-22.04 release...
2025/02/12 15:45:28 Processing /tmp/tmp.ssmgmhFRDG/chisel/releases/ubuntu-22.04 release...
2025/02/12 15:45:30 Selecting slices...
2025/02/12 15:45:30 Fetching ubuntu 22.04 jammy suite details...
2025/02/12 15:45:33 Release date: Thu, 21 Apr 2022 17:16:08 UTC
2025/02/12 15:45:33 Fetching index for ubuntu 22.04 jammy main component...
2025/02/12 15:45:34 Fetching index for ubuntu 22.04 jammy universe component...
2025/02/12 15:45:40 Fetching ubuntu 22.04 jammy-security suite details...
2025/02/12 15:45:40 Release date: Wed, 12 Feb 2025  8:19:09 UTC
2025/02/12 15:45:40 Fetching index for ubuntu 22.04 jammy-security main component...
2025/02/12 15:45:42 Fetching index for ubuntu 22.04 jammy-security universe component...
2025/02/12 15:45:43 Fetching ubuntu 22.04 jammy-updates suite details...
2025/02/12 15:45:43 Release date: Wed, 12 Feb 2025  8:21:23 UTC
2025/02/12 15:45:43 Fetching index for ubuntu 22.04 jammy-updates main component...
2025/02/12 15:45:44 Fetching index for ubuntu 22.04 jammy-updates universe component...
2025/02/12 15:45:45 Fetching ubuntu-fips-updates fips-updates (pro) 22.04 jammy-updates suite details...
2025/02/12 15:45:47 Release date: Mon, 03 Feb 2025 11:20:45 UTC
2025/02/12 15:45:47 Fetching index for ubuntu-fips-updates fips-updates (pro) 22.04 jammy-updates main component...
2025/02/12 15:45:49 Fetching ubuntu-esm-apps esm-apps (pro) 22.04 jammy-apps-security suite details...
2025/02/12 15:45:49 Release date: Mon, 10 Feb 2025 01:13:04 UTC
2025/02/12 15:45:49 Fetching index for ubuntu-esm-apps esm-apps (pro) 22.04 jammy-apps-security main component...
2025/02/12 15:45:50 Fetching ubuntu-esm-apps esm-apps (pro) 22.04 jammy-apps-updates suite details...
2025/02/12 15:45:51 Release date: Wed, 10 Aug 2022 20:35:13 UTC
2025/02/12 15:45:51 Fetching index for ubuntu-esm-apps esm-apps (pro) 22.04 jammy-apps-updates main component...
2025/02/12 15:45:51 Fetching ubuntu-esm-infra esm-infra (pro) 22.04 jammy-infra-security suite details...
2025/02/12 15:45:52 Release date: Wed, 10 Aug 2022 20:43:19 UTC
2025/02/12 15:45:52 Fetching index for ubuntu-esm-infra esm-infra (pro) 22.04 jammy-infra-security main component...
2025/02/12 15:45:52 Fetching ubuntu-esm-infra esm-infra (pro) 22.04 jammy-infra-updates suite details...
2025/02/12 15:45:52 Release date: Wed, 10 Aug 2022 20:43:19 UTC
2025/02/12 15:45:52 Fetching index for ubuntu-esm-infra esm-infra (pro) 22.04 jammy-infra-updates main component...
2025/02/12 15:45:52 Fetching pool/main/g/glibc/libc6_2.35-0ubuntu3.9_amd64.deb...
2025/02/12 15:45:56 Extracting files from package "libc6"...
```

</details>



<details>
<summary>Contents of `./status`</summary>

```
Package: libssl1.1
Source: openssl
Version: 1.1.1f-1ubuntu2.fips.23
Architecture: amd64
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Installed-Size: 4097
Depends: libc6 (>= 2.17), debconf (>= 0.5) | debconf-2.0
Recommends: libssl1.1-hmac (= 1.1.1f-1ubuntu2.fips.23)
Breaks: isync (<< 1.3.0-2), lighttpd (<< 1.4.49-2), python-boto (<< 2.44.0-1.1), python-httplib2 (<< 0.11.3-1), python-imaplib2 (<< 2.57-5), python3-boto (<< 2.44.0-1.1), python3-imaplib2 (<< 2.57-5)
Section: libs
Priority: optional
Multi-Arch: same
Homepage: https://www.openssl.org/
Description: Secure Sockets Layer toolkit - shared libraries
 This package is part of the OpenSSL project's implementation of the SSL
 and TLS cryptographic protocols for secure communication over the
 Internet.
 .
 It provides the libssl and libcrypto shared libraries.
Original-Maintainer: Debian OpenSSL Team <pkg-openssl-devel@lists.alioth.debian.org>

Package: openssl
Version: 1.1.1f-1ubuntu2.fips.23
Architecture: amd64
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Installed-Size: 1257
Depends: libc6 (>= 2.15), libssl1.1 (>= 1.1.1)
Suggests: ca-certificates
Section: utils
Priority: optional
Multi-Arch: foreign
Homepage: https://www.openssl.org/
Description: Secure Sockets Layer toolkit - cryptographic utility
 This package is part of the OpenSSL project's implementation of the SSL
 and TLS cryptographic protocols for secure communication over the
 Internet.
 .
 It contains the general-purpose command line binary /usr/bin/openssl,
 useful for cryptographic operations such as:
  * creating RSA, DH, and DSA key parameters;
  * creating X.509 certificates, CSRs, and CRLs;
  * calculating message digests;
  * encrypting and decrypting with ciphers;
  * testing SSL/TLS clients and servers;
  * handling S/MIME signed or encrypted mail.
Original-Maintainer: Debian OpenSSL Team <pkg-openssl-devel@lists.alioth.debian.org>

Package: libc6
Source: glibc
Version: 2.35-0ubuntu3.9
Architecture: amd64
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Installed-Size: 13597
Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)
Recommends: libidn2-0 (>= 2.0.5~), libnss-nis, libnss-nisplus
Suggests: glibc-doc, debconf | debconf-2.0, locales
Breaks: busybox (<< 1.30.1-6), fakeroot (<< 1.25.3-1.1ubuntu2~), hurd (<< 1:0.9.git20170910-1), ioquake3 (<< 1.36+u20200211.f2c61c1~dfsg-2~), iraf-fitsutil (<< 2018.07.06-4), libgegl-0.4-0 (<< 0.4.18), libtirpc1 (<< 0.2.3), locales (<< 2.35), locales-all (<< 2.35), macs (<< 2.2.7.1-3~), nocache (<< 1.1-1~), nscd (<< 2.35), openarena (<< 0.8.8+dfsg-4~), openssh-server (<< 1:8.2p1-4), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)
Replaces: libc6-amd64
Section: libs
Priority: optional
Multi-Arch: same
Homepage: https://www.gnu.org/software/libc/libc.html
Description: GNU C Library: Shared libraries
 Contains the standard libraries that are used by nearly all programs on
 the system. This package includes shared versions of the standard C library
 and the standard math library, as well as many others.
Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>
Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc
Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git

```

</details>

It did work. After the execution, the previous entry for `libc6` was removed and a new entry was appended to the bottom of the file with the new version from Jammy. 

<details>
<summary>Diff of `./status` files</summary>

```diff
22,45d21
< Package: libc6
< Source: glibc
< Version: 2.31-0ubuntu9.17
< Architecture: amd64
< Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
< Installed-Size: 13239
< Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)
< Recommends: libidn2-0 (>= 2.0.5~)
< Suggests: glibc-doc, debconf | debconf-2.0, locales
< Conflicts: openrc (<< 0.27-2~)
< Breaks: hurd (<< 1:0.9.git20170910-1), iraf-fitsutil (<< 2018.07.06-4), libtirpc1 (<< 0.2.3), locales (<< 2.31), locales-all (<< 2.31), nocache (<< 1.1-1~), nscd (<< 2.31), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)
< Replaces: libc6-amd64
< Section: libs
< Priority: optional
< Multi-Arch: same
< Homepage: https://www.gnu.org/software/libc/libc.html
< Description: GNU C Library: Shared libraries
<  Contains the standard libraries that are used by nearly all programs on
<  the system. This package includes shared versions of the standard C library
<  and the standard math library, as well as many others.
< Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>
< Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc
< Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git
< 
70a47,69
> 
> Package: libc6
> Source: glibc
> Version: 2.35-0ubuntu3.9
> Architecture: amd64
> Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
> Installed-Size: 13597
> Depends: libgcc-s1, libcrypt1 (>= 1:4.4.10-10ubuntu4)
> Recommends: libidn2-0 (>= 2.0.5~), libnss-nis, libnss-nisplus
> Suggests: glibc-doc, debconf | debconf-2.0, locales
> Breaks: busybox (<< 1.30.1-6), fakeroot (<< 1.25.3-1.1ubuntu2~), hurd (<< 1:0.9.git20170910-1), ioquake3 (<< 1.36+u20200211.f2c61c1~dfsg-2~), iraf-fitsutil (<< 2018.07.06-4), libgegl-0.4-0 (<< 0.4.18), libtirpc1 (<< 0.2.3), locales (<< 2.35), locales-all (<< 2.35), macs (<< 2.2.7.1-3~), nocache (<< 1.1-1~), nscd (<< 2.35), openarena (<< 0.8.8+dfsg-4~), openssh-server (<< 1:8.2p1-4), r-cran-later (<< 0.7.5+dfsg-2), wcc (<< 0.0.2+dfsg-3)
> Replaces: libc6-amd64
> Section: libs
> Priority: optional
> Multi-Arch: same
> Homepage: https://www.gnu.org/software/libc/libc.html
> Description: GNU C Library: Shared libraries
>  Contains the standard libraries that are used by nearly all programs on
>  the system. This package includes shared versions of the standard C library
>  and the standard math library, as well as many others.
> Original-Maintainer: GNU Libc Maintainers <debian-glibc@lists.debian.org>
> Original-Vcs-Browser: https://salsa.debian.org/glibc-team/glibc
> Original-Vcs-Git: https://salsa.debian.org/glibc-team/glibc.git
```
</details>