### PR TITLE
feat: add rebornplusplus/chisel-tools

### DIFF
--- a/chisel-tools/LICENSE
+++ b/chisel-tools/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/chisel-tools/cmd/sdf/cmd_install.go
+++ b/chisel-tools/cmd/sdf/cmd_install.go
@@ -1,0 +1,342 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/canonical/rocks-toolbox/chisel-tools/internal/chisel"
+	"github.com/canonical/rocks-toolbox/chisel-tools/internal/rmadison"
+)
+
+const (
+	tick  = '\u2713'
+	cross = '\u2717'
+)
+
+type cmdInstall struct {
+	Release string `short:"r" long:"release" description:"Chisel release path" required:"true"`
+	Arch    string `short:"a" long:"arch" description:"Package architecture" default:"amd64"`
+	Workers int    `short:"w" long:"workers" description:"Number of concurrent workers" default:"10"`
+
+	// You may use [Combine] and [Prune] together. The slices will be pruned
+	// first and then combined to install only the top level slices in one go.
+	Combine bool `long:"combine" description:"Install all slices in one go"`
+	Prune   bool `long:"prune" description:"Install only the top level slices"`
+
+	Continue bool `short:"c" long:"continue-on-error" description:"Continue on installation errors"`
+	Ignore   bool `long:"ignore-missing" description:"Ignore missing packages for an arch"`
+	Ensure   bool `long:"ensure-existence" description:"Ensure package existence for at least one arch"`
+
+	Positional struct {
+		Files []string `positional-arg-name:"slice definition files"`
+	} `positional-args:"yes" required:"true"`
+}
+
+func init() {
+	parser.AddCommand(
+		"install",
+		"Install slices",
+		"The install command installs all slices from the specified files",
+		&cmdInstall{},
+	)
+}
+
+func (c *cmdInstall) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+	if c.Workers <= 0 {
+		return fmt.Errorf("invalid value for --workers: %d", c.Workers)
+	}
+	if len(c.Positional.Files) == 0 {
+		return nil // There is nothing to do.
+	}
+
+	var slices []*chisel.Slice
+	for _, f := range c.Positional.Files {
+		s, err := chisel.ParseSlices(f)
+		if err != nil {
+			return fmt.Errorf("cannot parse slices from file %s: %w", f, err)
+		}
+		slices = append(slices, s...)
+	}
+
+	// "Ensure" and "Ignore" packages before pruning the slices, because once
+	// pruned, some packages may completely be omitted from these checks.
+	if c.Ensure || c.Ignore {
+		pkgInfo, err := c.queryArchive(slices)
+		if err != nil {
+			return err
+		}
+		if c.Ensure {
+			if err := ensurePackages(slices, pkgInfo); err != nil {
+				return fmt.Errorf("%c Could not ensure packages: %s", cross, err)
+			}
+		}
+		if c.Ignore {
+			slices = ignoreMissing(slices, pkgInfo, c.Arch)
+		}
+	}
+
+	if c.Prune {
+		slices = prune(slices)
+	}
+
+	g := group(slices, c.Combine)
+	return c.install(g)
+}
+
+// Group slices for installation. If combine is true, create only one group with
+// all slices in it.
+func group(slices []*chisel.Slice, combine bool) [][]string {
+	var grouped [][]string
+	if combine {
+		var names []string
+		for _, s := range slices {
+			names = append(names, s.Name)
+		}
+		grouped = append(grouped, names)
+	} else {
+		for _, s := range slices {
+			grouped = append(grouped, []string{s.Name})
+		}
+	}
+	return grouped
+}
+
+// Prune the list of slices and return only the top-level slices that no slice
+// depends on. Installing these slices alone should cover all of the slices.
+// It depends on the acyclic dependency policy of chisel slices.
+func prune(slices []*chisel.Slice) []*chisel.Slice {
+	log.Print("Pruning the list of slices...")
+
+	pending := make(map[string]*chisel.Slice)
+	for _, s := range slices {
+		pending[s.Name] = s
+	}
+	for _, s := range slices {
+		for _, e := range s.Essential {
+			delete(pending, e)
+		}
+	}
+	var todo []*chisel.Slice
+	for _, s := range slices {
+		if _, ok := pending[s.Name]; ok {
+			todo = append(todo, s)
+		}
+	}
+	return todo
+}
+
+// Install the groups of slices, concurrently.
+func (c *cmdInstall) install(slices [][]string) error {
+	if len(slices) == 0 {
+		log.Printf("%c Nothing to install :)", tick)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tasks := make(chan *task, len(slices)) // Tasks to finish.
+	errs := make(chan error, len(slices))  // Errors from the tasks, if any.
+	for _, s := range slices {
+		tasks <- &task{
+			args:   []string{"cut", "--release", c.Release, "--arch", c.Arch},
+			slices: s,
+		}
+	}
+	close(tasks)
+
+	done := make(chan bool) // Indicates that the workers are done.
+	var wg sync.WaitGroup
+	for range min(c.Workers, len(slices)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			worker(ctx, tasks, errs)
+		}()
+	}
+	go func() {
+		wg.Wait()
+		// Wait 1 second before sending the done signal as the workers might
+		// send an error to the "errs" channel at the same time.
+		time.Sleep(1 * time.Second)
+		done <- true
+	}()
+
+	var allErrs error
+loop:
+	for {
+		select {
+		case <-done:
+			break loop
+		case err := <-errs:
+			if err == nil {
+				continue
+			}
+			if !c.Continue {
+				cancel()
+				return err
+			}
+			allErrs = errors.Join(allErrs, err)
+		}
+	}
+	return allErrs
+}
+
+type task struct {
+	args   []string // Chisel arguments without positional slice name(s).
+	slices []string // Positional argument - slice name(s) to install.
+}
+
+// worker does the actual installation of a list of slices by executing the
+// chisel cut command in another process.
+// It takes in a context to interrupt when necessary, a stream (channel) of
+// tasks and a channel to send errors to.
+func worker(ctx context.Context, tasks <-chan *task, errs chan<- error) {
+	// We are using an independent cache directory for chisel in each worker.
+	// The reason is tricky to detect. When creating files in cache, Chisel
+	// temporary saves a file as "<digest>.tmp" in the cache directory.[^1]
+	// It later renames the file to "<digest>" within the same directory.[^2]
+	// This is OK, if two chisel operations are sequential and/or do not try to
+	// "create" the cache at the same time. But on concurrent operations, the
+	// second process fails to rename the temporary file and eventually fails.
+	//
+	//   error: cannot fetch from archive: rename
+	//   /home/runner/.cache/chisel/sha256/6b8cc68643d18250ab297c4f6d427a8778b1d1534e1a3033fff0f221fa20a419.tmp
+	//   /home/runner/.cache/chisel/sha256/6b8cc68643d18250ab297c4f6d427a8778b1d1534e1a3033fff0f221fa20a419:
+	//   no such file or directory
+	//
+	// [^1]: https://github.com/canonical/chisel/blob/main/internal/cache/cache.go#L112
+	// [^2]: https://github.com/canonical/chisel/blob/main/internal/cache/cache.go#L80
+	cacheDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		errs <- fmt.Errorf("cannot create temporary directory: %w", err)
+		return
+	}
+
+	do := func(task *task) {
+		name := strings.Join(task.slices, " ")
+		log.Printf("Installing %s...", name)
+
+		dir, err := os.MkdirTemp("", "")
+		if err != nil {
+			errs <- fmt.Errorf("cannot create temporary directory: %w", err)
+			return
+		}
+		defer os.RemoveAll(dir)
+
+		args := append(task.args, "--root", dir)
+		args = append(args, task.slices...)
+
+		cmd := exec.CommandContext(ctx, "chisel", args...)
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, "XDG_CACHE_HOME="+cacheDir)
+
+		if out, err := cmd.CombinedOutput(); err != nil {
+			if e, ok := err.(*exec.ExitError); ok && e.ProcessState.ExitCode() != -1 {
+				err = fmt.Errorf("%c Failed to install %s: %w", cross, name, err)
+				log.Printf("%s\n%s", err, out)
+			}
+			errs <- err
+		} else {
+			log.Printf("%c Installed %s", tick, name)
+		}
+	}
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break loop // Context cancelled. Quit.
+		case task, ok := <-tasks:
+			if !ok {
+				break loop // No more tasks. Quit.
+			}
+			do(task)
+		}
+	}
+}
+
+// Query the archives for package existence, using the chisel.yaml
+// configurations.
+func (c *cmdInstall) queryArchive(slices []*chisel.Slice) (map[string]*rmadison.Result, error) {
+	p := filepath.Join(c.Release, "chisel.yaml")
+	cfg, err := chisel.ParseConfig(p)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse chisel.yaml: %w", err)
+	}
+	ubuntu, ok := cfg.Archives["ubuntu"]
+	if !ok {
+		return nil, fmt.Errorf("no 'ubuntu' archive in chisel.yaml")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	var pkgs []string
+	exists := make(map[string]struct{})
+	for _, s := range slices {
+		if _, ok := exists[s.Package]; !ok {
+			pkgs = append(pkgs, s.Package)
+			exists[s.Package] = struct{}{}
+		}
+	}
+	res, err := rmadison.QueryWithContext(ctx, &rmadison.QueryOptions{
+		Component: ubuntu.Components,
+		Suite:     ubuntu.Suites,
+		Package:   pkgs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cannot query archives: %w", err)
+	}
+	pkgInfo := make(map[string]*rmadison.Result)
+	for _, r := range res {
+		pkgInfo[r.Package] = r
+	}
+	return pkgInfo, nil
+}
+
+// Ensure that the slice packages exist for at least one arch.
+func ensurePackages(slices []*chisel.Slice, pkgInfo map[string]*rmadison.Result) error {
+	log.Println("Ensuring slice packages existence...")
+	for _, s := range slices {
+		if _, ok := pkgInfo[s.Package]; !ok {
+			return fmt.Errorf("package %q does not exist", s.Package)
+		}
+	}
+	return nil
+}
+
+// Ignore missing slice packages for a particular arch.
+func ignoreMissing(slices []*chisel.Slice, pkgInfo map[string]*rmadison.Result, arch string) []*chisel.Slice {
+	log.Printf("Ignoring missing slice packages on %s...", arch)
+	var found []*chisel.Slice
+	missing := make(map[string]bool)
+	for _, s := range slices {
+		// Use the missing map to avoid costly [strings.Contains] operation
+		// below for all slices of a package.
+		if miss, ok := missing[s.Package]; ok {
+			if !miss {
+				found = append(found, s)
+			}
+			continue
+		}
+		info, ok := pkgInfo[s.Package]
+		if ok && (strings.Contains(info.Arch, arch) || strings.Contains(info.Arch, "all")) {
+			found = append(found, s)
+			missing[s.Package] = false
+			continue
+		}
+		log.Printf("... ignored %s for %s", s.Package, arch)
+		missing[s.Package] = true
+	}
+	return found
+}

--- a/chisel-tools/cmd/sdf/cmd_install_test.go
+++ b/chisel-tools/cmd/sdf/cmd_install_test.go
@@ -1,0 +1,121 @@
+package main_test
+
+import (
+	"reflect"
+	"testing"
+
+	sdf "github.com/canonical/rocks-toolbox/chisel-tools/cmd/sdf"
+	"github.com/canonical/rocks-toolbox/chisel-tools/internal/chisel"
+	"github.com/canonical/rocks-toolbox/chisel-tools/internal/rmadison"
+)
+
+var pruneTests = []struct {
+	slices []*chisel.Slice
+	pruned []string
+}{{
+	slices: []*chisel.Slice{{
+		Name: "pkg1_slice1",
+		Essential: []string{
+			"pkg2_slice1",
+			"pkg1_slice2",
+		},
+	}, {
+		Name: "pkg1_slice2",
+	}, {
+		Name: "pkg2_slice1",
+		Essential: []string{
+			"pkg1_slice2",
+		},
+	}, {
+		Name: "pkg3_slice1",
+	}},
+	pruned: []string{
+		"pkg1_slice1",
+		"pkg3_slice1",
+	},
+}}
+
+func TestPrune(t *testing.T) {
+	for _, tc := range pruneTests {
+		slices := sdf.Prune(tc.slices)
+		var pruned []string
+		for _, s := range slices {
+			pruned = append(pruned, s.Name)
+		}
+		if !reflect.DeepEqual(pruned, tc.pruned) {
+			t.Fatalf("have %v, want %v", pruned, tc.pruned)
+		}
+	}
+}
+
+var ensureIgnoreTests = []struct {
+	slices    []*chisel.Slice             // List of slices to ensure, or ignore missing.
+	pkgs      map[string]*rmadison.Result // Package info from rmadison query.
+	arch      string                      // Package arch to ignore missing for.
+	ensureErr string                      // Expected ensure-existing errors.
+	found     []*chisel.Slice             // Expected slices which are not to be ignored.
+}{{
+	slices: []*chisel.Slice{{
+		Name:    "hello_bins",
+		Package: "hello",
+	}, {
+		Name:    "hello_copyright",
+		Package: "hello",
+	}, {
+		Name:    "python3_core",
+		Package: "python3",
+	}, {
+		Name:    "libc6_libs",
+		Package: "libc6",
+	}, {
+		Name:    "java_extra",
+		Package: "java",
+	}},
+	pkgs: map[string]*rmadison.Result{
+		"hello": {
+			Arch: "amd64, arm64, i386",
+		},
+		"libc6": {
+			Arch: "all",
+		},
+		"java": {
+			Arch: "arm64, i386",
+		},
+	},
+	arch:      "amd64",
+	ensureErr: `package "python3" does not exist`,
+	found: []*chisel.Slice{{
+		Name:    "hello_bins",
+		Package: "hello",
+	}, {
+		Name:    "hello_copyright",
+		Package: "hello",
+	}, {
+		Name:    "libc6_libs",
+		Package: "libc6",
+	}},
+}}
+
+func TestEnsurePackages(t *testing.T) {
+	for _, tc := range ensureIgnoreTests {
+		err := sdf.EnsurePackages(tc.slices, tc.pkgs)
+		if tc.ensureErr != "" {
+			if err.Error() != tc.ensureErr {
+				t.Fatalf("have error %q, want %q", err, tc.ensureErr)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("have error %q, want nil", err)
+			}
+		}
+	}
+}
+
+func TestIgnoreMissing(t *testing.T) {
+	for _, tc := range ensureIgnoreTests {
+		slices := sdf.IgnoreMissing(tc.slices, tc.pkgs, tc.arch)
+		if !reflect.DeepEqual(slices, tc.found) {
+			t.Fatalf("have %v, want %v", slices, tc.found)
+		}
+	}
+}

--- a/chisel-tools/cmd/sdf/export_test.go
+++ b/chisel-tools/cmd/sdf/export_test.go
@@ -1,0 +1,7 @@
+package main
+
+var (
+	Prune          = prune
+	EnsurePackages = ensurePackages
+	IgnoreMissing  = ignoreMissing
+)

--- a/chisel-tools/cmd/sdf/main.go
+++ b/chisel-tools/cmd/sdf/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+)
+
+// ErrExtraArgs is returned  if extra arguments to a command are found
+var ErrExtraArgs = fmt.Errorf("too many arguments for command")
+
+var parser = flags.NewParser(&struct{}{}, flags.Default)
+
+func main() {
+	// We do not care for any date/time prefix on the logs.
+	log.SetFlags(0)
+
+	if _, err := parser.Parse(); err != nil {
+		switch flagsErr := err.(type) {
+		case flags.ErrorType:
+			if flagsErr == flags.ErrHelp {
+				os.Exit(0)
+			}
+			os.Exit(1)
+		default:
+			os.Exit(1)
+		}
+	}
+}

--- a/chisel-tools/go.mod
+++ b/chisel-tools/go.mod
@@ -1,0 +1,10 @@
+module github.com/canonical/rocks-toolbox/chisel-tools
+
+go 1.24
+
+require (
+	github.com/jessevdk/go-flags v1.6.1
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require golang.org/x/sys v0.32.0 // indirect

--- a/chisel-tools/go.sum
+++ b/chisel-tools/go.sum
@@ -1,0 +1,8 @@
+github.com/jessevdk/go-flags v1.6.1 h1:Cvu5U8UGrLay1rZfv/zP7iLpSHGUZ/Ou68T0iX1bBK4=
+github.com/jessevdk/go-flags v1.6.1/go.mod h1:Mk8T1hIAWpOiJiHa9rJASDK2UGWji0EuPGBnNLMooyc=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/chisel-tools/internal/chisel/config.go
+++ b/chisel-tools/internal/chisel/config.go
@@ -1,0 +1,56 @@
+package chisel
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// chisel.yaml, for a lack of a better name, is the config for Chisel.
+// The "v2-archives" field will be merged into "archives" after parsing.
+type Config struct {
+	Archives   map[string]*Archive `yaml:"archives"`
+	V2Archives map[string]*Archive `yaml:"v2-archives"`
+	// TODO add remaining fields when necessary.
+}
+
+type Archive struct {
+	Suites     []string `yaml:"suites"`
+	Components []string `yaml:"components"`
+	// TODO add remaining fields when necessary.
+}
+
+// Parse the chisel.yaml file given it's path.
+func ParseConfig(path string) (*Config, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	cfg := &Config{}
+	d := yaml.NewDecoder(f)
+	if err := d.Decode(cfg); err != nil {
+		return nil, err
+	}
+
+	for k, v := range cfg.V2Archives {
+		cfg.Archives[k] = v
+		delete(cfg.V2Archives, k)
+	}
+	cfg.V2Archives = nil
+
+	if len(cfg.Archives) == 0 {
+		return nil, fmt.Errorf("no 'archives' specified")
+	}
+	for name, a := range cfg.Archives {
+		if len(a.Suites) == 0 {
+			return nil, fmt.Errorf("archive %s has no 'suites'", name)
+		}
+		if len(a.Components) == 0 {
+			return nil, fmt.Errorf("archive %s has no 'components'", name)
+		}
+	}
+	return cfg, nil
+}

--- a/chisel-tools/internal/chisel/config_test.go
+++ b/chisel-tools/internal/chisel/config_test.go
@@ -1,0 +1,62 @@
+package chisel_test
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/canonical/rocks-toolbox/chisel-tools/internal/chisel"
+)
+
+const sampleChiselYaml = `
+archives:
+  foo:
+    suites: [a, b, c]
+    components: [p, q, r]
+v2-archives:
+  bar:
+    suites: [x]
+    components: [y, z]
+`
+
+var chiselYamlTests = []struct {
+	summary string
+	data    string
+	config  *chisel.Config
+}{{
+	summary: "Sample chisel.yaml",
+	data:    sampleChiselYaml,
+	config: &chisel.Config{
+		Archives: map[string]*chisel.Archive{
+			"foo": {
+				Suites:     []string{"a", "b", "c"},
+				Components: []string{"p", "q", "r"},
+			},
+			"bar": {
+				Suites:     []string{"x"},
+				Components: []string{"y", "z"},
+			},
+		},
+	},
+}}
+
+func TestParseConfig(t *testing.T) {
+	for _, tc := range chiselYamlTests {
+		f, err := os.CreateTemp("", "chisel.yaml")
+		if err != nil {
+			t.Fatal("cannot create temporary file")
+		}
+		defer os.Remove(f.Name())
+
+		f.WriteString(tc.data)
+		defer f.Close()
+
+		cfg, err := chisel.ParseConfig(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(cfg, tc.config) {
+			t.Fatalf("have %v, want %v", cfg, tc.config)
+		}
+	}
+}

--- a/chisel-tools/internal/chisel/slices.go
+++ b/chisel-tools/internal/chisel/slices.go
@@ -1,0 +1,84 @@
+package chisel
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The interesting bits about a chisel slice.
+type Slice struct {
+	Name      string   `yaml:"-"`
+	Package   string   `yaml:"-"`
+	Essential []string `yaml:"essential,omitempty"`
+	// TODO add remaining fields when necessary.
+}
+
+type sliceDef struct {
+	Package   string           `yaml:"package"`
+	Essential []string         `yaml:"essential,omitempty"`
+	Slices    map[string]Slice `yaml:"slices"`
+}
+
+// Parse all slices from a slice definition file.
+func ParseSlices(path string) ([]*Slice, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	def := &sliceDef{}
+	d := yaml.NewDecoder(f)
+	if err := d.Decode(def); err != nil {
+		return nil, err
+	}
+
+	if def.Package == "" {
+		return nil, fmt.Errorf("missing 'package' field")
+	}
+	if len(def.Slices) == 0 {
+		return nil, fmt.Errorf("missing 'slices' field")
+	}
+	for _, s := range def.Essential {
+		if _, _, err := Parse(s); err != nil {
+			return nil, fmt.Errorf("'essential': %w", err)
+		}
+	}
+
+	var slices []*Slice
+	for name, slice := range def.Slices {
+		for _, e := range slice.Essential {
+			if _, _, err := Parse(e); err != nil {
+				return nil, fmt.Errorf("slice %s 'essential': %w", name, err)
+			}
+		}
+		slice.Essential = append(slice.Essential, def.Essential...)
+		slice.Name = Name(def.Package, name)
+		slice.Package = def.Package
+		slices = append(slices, &slice)
+	}
+	sort.Slice(slices, func(i, j int) bool {
+		return slices[i].Name < slices[j].Name
+	})
+	return slices, nil
+}
+
+func Name(pkg, slice string) string {
+	return pkg + "_" + slice
+}
+
+func Parse(name string) (pkg, slice string, err error) {
+	i := strings.Index(name, "_")
+	if i < 0 {
+		return "", "", fmt.Errorf("invalid slice name: %s", name)
+	}
+	pkg, slice = name[:i], name[i+1:]
+	if strings.Contains(slice, "_") {
+		return "", "", fmt.Errorf("invalid slice name: %s", name)
+	}
+	return pkg, slice, nil
+}

--- a/chisel-tools/internal/chisel/slices_test.go
+++ b/chisel-tools/internal/chisel/slices_test.go
@@ -1,0 +1,68 @@
+package chisel_test
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/canonical/rocks-toolbox/chisel-tools/internal/chisel"
+)
+
+const sampleSlice = `
+package: foo
+essential:
+  - bar_foo
+slices:
+  foo:
+    essential:
+      - bar_bar
+  bar:
+    essential:
+      - foo_foo
+      - buz_foo
+    extra: # extra field, must be ignored
+      - foo
+extra: # extra field, must be ignored.
+  foo: bar
+`
+
+var sliceData = []struct {
+	summary string
+	data    string
+	slices  []*chisel.Slice
+}{{
+	summary: "Sample slice definition file",
+	data:    sampleSlice,
+	slices: []*chisel.Slice{{
+		Name:      "foo_bar",
+		Package:   "foo",
+		Essential: []string{"foo_foo", "buz_foo", "bar_foo"},
+	}, {
+		Name:      "foo_foo",
+		Package:   "foo",
+		Essential: []string{"bar_bar", "bar_foo"},
+	}},
+}}
+
+func TestParseSliceDef(t *testing.T) {
+	for _, tc := range sliceData {
+		t.Logf("Summary: %s", tc.summary)
+
+		f, err := os.CreateTemp("", "slice")
+		if err != nil {
+			t.Fatal("cannot create temporary file")
+		}
+		defer os.Remove(f.Name())
+
+		f.WriteString(tc.data)
+		defer f.Close()
+
+		slices, err := chisel.ParseSlices(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(slices, tc.slices) {
+			t.Fatalf("have %v, want %v", slices, tc.slices)
+		}
+	}
+}

--- a/chisel-tools/internal/rmadison/export_test.go
+++ b/chisel-tools/internal/rmadison/export_test.go
@@ -1,0 +1,6 @@
+package rmadison
+
+var (
+	CmdArgs      = cmdArgs
+	FormatOutput = formatOutput
+)

--- a/chisel-tools/internal/rmadison/rmadison.go
+++ b/chisel-tools/internal/rmadison/rmadison.go
@@ -1,0 +1,103 @@
+// Package rmadison displays information about Debian packages using the
+// rmadison(1) tool. On Ubuntu, it comes in the devscripts package.
+package rmadison
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+)
+
+type QueryOptions struct {
+	Arch      []string
+	Component []string
+	Suite     []string
+	Package   []string
+}
+
+// Query performs a "rmadison .." command query. It returns the stdout as a
+// string if there are no errors. Otherwise, it returns an error.
+func Query(opts *QueryOptions) ([]*Result, error) {
+	log.Print("Querying the remote archive(s)...")
+	cmd := exec.Command("rmadison", cmdArgs(opts)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return formatOutput(string(out))
+}
+
+// QueryWithContext is similar to [Query], except it takes a context in addition
+// to interrupt the execution if needed.
+func QueryWithContext(ctx context.Context, opts *QueryOptions) ([]*Result, error) {
+	log.Println("Querying the remote archive(s)...")
+	cmd := exec.CommandContext(ctx, "rmadison", cmdArgs(opts)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return formatOutput(string(out))
+}
+
+func cmdArgs(opts *QueryOptions) []string {
+	var args []string
+	if opts == nil {
+		return args
+	}
+	if len(opts.Arch) > 0 {
+		args = append(args, "-a", strings.Join(opts.Arch, ","))
+	}
+	if len(opts.Component) > 0 {
+		args = append(args, "-c", strings.Join(opts.Component, ","))
+	}
+	if len(opts.Suite) > 0 {
+		args = append(args, "-s", strings.Join(opts.Suite, ","))
+	}
+	args = append(args, opts.Package...)
+	return args
+}
+
+// The result entries have 4 fields separated by a vertical bar ("|") - package
+// name, version, suite(s), arch(s).
+type Result struct {
+	Package string
+	Version string
+	Suite   string
+	Arch    string
+}
+
+func parse(s string) (*Result, error) {
+	parts := strings.Split(s, "|")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid format: %s", s)
+	}
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return &Result{
+		Package: parts[0],
+		Version: parts[1],
+		Suite:   parts[2],
+		Arch:    parts[3],
+	}, nil
+}
+
+func formatOutput(s string) ([]*Result, error) {
+	s = strings.TrimSpace(s)
+	lines := strings.Split(s, "\n")
+	var res []*Result
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		r, err := parse(l)
+		if err != nil {
+			return nil, fmt.Errorf("cannot format output: %w", err)
+		}
+		res = append(res, r)
+	}
+	return res, nil
+}

--- a/chisel-tools/internal/rmadison/rmadison_test.go
+++ b/chisel-tools/internal/rmadison/rmadison_test.go
@@ -1,0 +1,105 @@
+package rmadison_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/canonical/rocks-toolbox/chisel-tools/internal/rmadison"
+)
+
+const sampleOut = `
+ hello | 2.10-1build3  | bionic-updates  | source, amd64, i386, ppc64el, s390x
+ libc6 | 2.10-2ubuntu2 | focal           | source, arm64, armhf, riscv64
+`
+
+var formatOutputTests = []struct {
+	output string
+	result []*rmadison.Result
+	err    string
+}{{
+	output: sampleOut,
+	result: []*rmadison.Result{{
+		"hello", "2.10-1build3", "bionic-updates", "source, amd64, i386, ppc64el, s390x",
+	}, {
+		"libc6", "2.10-2ubuntu2", "focal", "source, arm64, armhf, riscv64",
+	}},
+}, {
+	output: "",
+}, {
+	output: "\n\n\n",
+}, {
+	output: "foo | bar | baz",
+	err:    "cannot format output: invalid format: foo | bar | baz",
+}}
+
+func TestFormatOutput(t *testing.T) {
+	for _, tc := range formatOutputTests {
+		res, err := rmadison.FormatOutput(tc.output)
+		if tc.err != "" {
+			if err.Error() != tc.err {
+				t.Fatalf("have error %q, want %q", err, tc.err)
+			}
+			continue
+		} else {
+			if err != nil {
+				t.Fatalf("have error %s, want nil", err)
+			}
+		}
+		if !reflect.DeepEqual(res, tc.result) {
+			t.Fatalf("have %v, want %v", res, tc.result)
+		}
+	}
+}
+
+var cmdArgsTests = []struct {
+	opts *rmadison.QueryOptions
+	args []string
+}{{
+	opts: &rmadison.QueryOptions{
+		Arch:      []string{"amd64", "armhf"},
+		Component: []string{"main", "universe"},
+		Suite:     []string{"focal", "jammy"},
+		Package:   []string{"hello", "libc6"},
+	},
+	args: []string{
+		"-a", "amd64,armhf",
+		"-c", "main,universe",
+		"-s", "focal,jammy",
+		"hello",
+		"libc6",
+	},
+}, {
+	opts: &rmadison.QueryOptions{
+		Arch:      []string{"amd64"},
+		Component: []string{"main"},
+		Suite:     []string{"focal"},
+		Package:   []string{"hello", "libc6"},
+	},
+	args: []string{
+		"-a", "amd64",
+		"-c", "main",
+		"-s", "focal",
+		"hello",
+		"libc6",
+	},
+}, {
+	opts: &rmadison.QueryOptions{
+		Package: []string{"hello"},
+	},
+	args: []string{"hello"},
+}, {
+	opts: &rmadison.QueryOptions{},
+	args: nil,
+}, {
+	opts: nil,
+	args: nil,
+}}
+
+func TestCmdArgs(t *testing.T) {
+	for _, tc := range cmdArgsTests {
+		args := rmadison.CmdArgs(tc.opts)
+		if !reflect.DeepEqual(args, tc.args) {
+			t.Fatalf("have %v, want %v", args, tc.args)
+		}
+	}
+}


### PR DESCRIPTION
The chisel-tools go package contains command line tool(s) that helps working with chisel and chisel slices. In it's current state, the "sdf" utility from the chisel-tools helps verify the installation of slices from slice definition files. This can replace some of the CI in the canonical/chisel-releases repository.

The go package is copied from [`github.com/rebornplusplus/chisel-tools`](https://github.com/rebornplusplus/chisel-tools). Furthermore, the name is changed to
`github.com/canonical/rocks-toolbox/chisel-tools`. Once this PR is merged, we will need to register this package in https://pkg.go.dev.